### PR TITLE
Fixing dependency name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "5.0.*",
         "illuminate/view": "5.0.*",
-        "ronan-gloo/jadephp": "dev-master"
+        "ronan-gloo/jade-php": "dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Looks like this was renamed at some point.

Also, it looks to me like https://github.com/kylekatarnls/jade-php is more maintained, you may want to switch to his fork and release a new major version.